### PR TITLE
feature: add original value to mapping

### DIFF
--- a/sparkle/backend/api/sanitize.py
+++ b/sparkle/backend/api/sanitize.py
@@ -31,14 +31,18 @@ def sanitize_data():
                                    allow_list=allow_list,
                                    deny_list=deny_list)
     sanitized_text = sanitized_obj.fake
-    spans = sanitized_obj.spans
     template = sanitized_obj.template
+
+    original_spans = sorted(sanitized_obj.original_spans, key=lambda x: x['start'])
+    sanitized_spans = sorted(sanitized_obj.spans, key=lambda x: x.start)
+
+    for original_span, sanitized_span in zip(original_spans, sanitized_spans):
+        sanitized_span.original_value = text[original_span['start']:original_span['end']]
 
     return json.dumps({
         'sanitized_text': sanitized_text,
         'original_text': text,
-        'spans': [span.__dict__ for span in spans],
-        'mapping': [], #TODO: source_entity, mapped_entity
+        'spans': [span.__dict__ for span in sanitized_spans],
         'template': template
     }), 200
 

--- a/sparkle/backend/util/sanitize_util.py
+++ b/sparkle/backend/util/sanitize_util.py
@@ -62,6 +62,15 @@ def anonymize_text(text_to_anonymize: str, entities: Optional[List[str]] = None,
                                         allow_list=allow_list,
                                         language=language,
                                         ad_hoc_recognizers=ad_hoc_recognizers)
+
+    original_spans = []
+    for result in analyzer_results:
+        original_spans.append({
+            'start': result.start,
+            'end': result.end,
+            'entity_type': ENTITY_MAP[result.entity_type]
+        })
+
     # pass Analyzer results into the anonymizer
     anonymizer = AnonymizerEngine()
     anonymized_results = anonymizer.anonymize(
@@ -81,4 +90,5 @@ def anonymize_text(text_to_anonymize: str, entities: Optional[List[str]] = None,
         templates=sentence_templates, n_samples=1)
     fake_records_list = list(fake_records)
     result = fake_records_list[0]
+    result.original_spans = original_spans
     return result


### PR DESCRIPTION
Added a new value in spans "original_value" which shows what the text was mapped from

Notion ticket: https://www.notion.so/storytell-ai/1b11efe98bab459182c96373f93fa879?v=b8c7e910a4144ec08e0b94ab05397560&p=a570166146cd467cbe490bbba5b43ab8&pm=s
Demo: https://share.getcloudapp.com/RBuJbZgA